### PR TITLE
feat: Add CUDA-aware MPI example

### DIFF
--- a/RC_example_jobs/cuda_mpi/README.md
+++ b/RC_example_jobs/cuda_mpi/README.md
@@ -1,0 +1,12 @@
+# CUDA aware MPI
+
+This example is based on the tutorial here: <https://www.olcf.ornl.gov/tutorials/gpudirect-mpich-enabled-cuda>.
+
+To compile:
+
+```bash
+module load intel/19.1 cudatoolkit openmpi/cuda-10.2/intel-19.1
+mpicc -lcudart direct.c -o direct.out
+```
+
+Then submit with the provided `submit.sbatch`.

--- a/RC_example_jobs/cuda_mpi/direct.c
+++ b/RC_example_jobs/cuda_mpi/direct.c
@@ -1,0 +1,79 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <cuda_runtime.h>
+#include <mpi.h>
+#include <mpi-ext.h>
+
+/* Based on the tutorial here:  https://www.olcf.ornl.gov/tutorials/gpudirect-mpich-enabled-cuda/ */
+
+int main( int argc, char** argv ) {
+
+    MPI_Init (&argc, &argv);
+
+    int direct;
+    int rank, size;
+    int *h_buff = NULL;
+    void *d_rank = NULL;
+    void *d_buff = NULL;
+    size_t bytes;
+    int i;
+
+    // Get MPI rank and size
+    MPI_Comm_rank (MPI_COMM_WORLD, &rank);
+    MPI_Comm_size (MPI_COMM_WORLD, &size);
+
+    if(rank == 0) {
+        printf("Compile time check:\n");
+#       if defined(MPIX_CUDA_AWARE_SUPPORT) && MPIX_CUDA_AWARE_SUPPORT
+            printf("This MPI library has CUDA-aware support.\n");
+#       elif defined(MPIX_CUDA_AWARE_SUPPORT) && !MPIX_CUDA_AWARE_SUPPORT
+            printf("This MPI library does not have CUDA-aware support.\n");
+#       else
+            printf("This MPI library cannot determine if there is CUDA-aware support.\n");
+#       endif /* MPIX_CUDA_AWARE_SUPPORT */
+
+        printf("Run time check:\n");
+#       if defined(MPIX_CUDA_AWARE_SUPPORT)
+            if (1 == MPIX_Query_cuda_support()) {
+                printf("This MPI library has CUDA-aware support.\n");
+            } else {
+                printf("This MPI library does not have CUDA-aware support.\n");
+            }
+#       else /* !defined(MPIX_CUDA_AWARE_SUPPORT) */
+            printf("This MPI library cannot determine if there is CUDA-aware support.\n");
+#       endif /* MPIX_CUDA_AWARE_SUPPORT */
+    }
+
+    // Allocate host and device buffers and copy rank value to GPU
+    bytes = size*sizeof(int);
+    h_buff = (int*)malloc(bytes);
+    cudaMalloc(&d_buff, bytes);
+    cudaMalloc(&d_rank, sizeof(int));
+    cudaMemcpy(d_rank, &rank, sizeof(int), cudaMemcpyHostToDevice);
+
+    // Sync at this point (would make log nicer)
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    // Preform Allgather using device buffer
+    MPI_Allgather(d_rank, 1, MPI_INT, d_buff, 1, MPI_INT, MPI_COMM_WORLD);
+
+    // Check that the GPU buffer is correct
+    cudaMemcpy(h_buff, d_buff, bytes, cudaMemcpyDeviceToHost);
+    for(i=0; i<size; i++){
+        if(h_buff[i] != i) {
+            printf ("Alltoall Failed!\n");
+            exit (EXIT_FAILURE);
+        }
+    }
+
+    if(rank==0)
+        printf("Success!\n");
+
+    // Clean up
+    free(h_buff);
+    cudaFree(d_buff);
+    cudaFree(d_rank);
+    MPI_Finalize();
+
+    return 0;
+}

--- a/RC_example_jobs/cuda_mpi/submit.sbatch
+++ b/RC_example_jobs/cuda_mpi/submit.sbatch
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=multiGPUtest  # create a short name for your job
+#SBATCH --nodes=1                # node count
+#SBATCH --ntasks=2               # total number of tasks across all nodes
+#SBATCH --cpus-per-task=1        # cpu-cores per task (>1 if multi-threaded tasks)
+#SBATCH --mem-per-cpu=1G         # memory per cpu-core (4G is default)
+#SBATCH --gres=gpu:2             # number of gpus per node
+#SBATCH --time=00:00:30          # total run time limit (HH:MM:SS)
+#SBATCH --reservation=hackathon  # name of reservation
+
+module load intel/19.1 cudatoolkit openmpi/cuda-10.2/intel-19.1
+module list
+
+srun --gpus=2 --gpus-per-task=1 ./direct.out


### PR DESCRIPTION
This adds a CUDA-aware MPI example.

Here's the current output:

```
Currently Loaded Modulefiles:
  1) intel-mkl/2020.1/1/64
  2) intel/19.1/64/19.1.1.217
  3) cudatoolkit/10.2
  4) openmpi/cuda-10.2/intel-19.1/4.0.3/64
[adroit-h11g1:04999] mca_base_component_repository_open: unable to open mca_btl_usnic: libfabric.so.1: cannot open shared object file: No such file or directory (ignored)
[adroit-h11g1:05000] mca_base_component_repository_open: unable to open mca_btl_usnic: libfabric.so.1: cannot open shared object file: No such file or directory (ignored)
--------------------------------------------------------------------------
By default, for Open MPI 4.0 and later, infiniband ports on a device
are not used by default.  The intent is to use UCX for these devices.
You can override this policy by setting the btl_openib_allow_ib MCA parameter
to true.

  Local host:              adroit-h11g1
  Local adapter:           mlx4_0
  Local port:              1

--------------------------------------------------------------------------
--------------------------------------------------------------------------
WARNING: There was an error initializing an OpenFabrics device.

  Local host:   adroit-h11g1
  Local device: mlx4_0
--------------------------------------------------------------------------
--------------------------------------------------------------------------
By default, for Open MPI 4.0 and later, infiniband ports on a device
are not used by default.  The intent is to use UCX for these devices.
You can override this policy by setting the btl_openib_allow_ib MCA parameter
to true.

  Local host:              adroit-h11g1
  Local adapter:           mlx4_0
  Local port:              1

--------------------------------------------------------------------------
--------------------------------------------------------------------------
WARNING: There was an error initializing an OpenFabrics device.

  Local host:   adroit-h11g1
  Local device: mlx4_0
--------------------------------------------------------------------------
[adroit-h11g1:05000] mca_base_component_repository_open: unable to open mca_mtl_ofi: libfabric.so.1: cannot open shared object file: No such file or directory (ignored)
[adroit-h11g1:04999] mca_base_component_repository_open: unable to open mca_mtl_ofi: libfabric.so.1: cannot open shared object file: No such file or directory (ignored)
Compile time check:
This MPI library has CUDA-aware support.
Run time check:
This MPI library has CUDA-aware support.
Success!
```